### PR TITLE
Adding gnupg library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/postgresql_role/tree/develop)
+- *[#31] Fixing sometimes missing gnupg library* @plozano94
 
 ## [1.4.2](https://github.com/idealista/postgresql_role/tree/1.4.2)
 [Full Changelog](https://github.com/idealista/postgresql_role/compare/1.4.1...1.4.2)

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -28,3 +28,4 @@ pg_config_files:
 
 pg_required_libs:
    - python3-psycopg2
+   - gnupg


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

Some Debian 11 dont have gnupg package and its necessarily inside this role.

### Benefits

Working in every Debian11

### Possible Drawbacks

Unknown

### Applicable Issues

#31 
